### PR TITLE
Potential fix for code scanning alert no. 33: Identical operands

### DIFF
--- a/src/utils/apiUtils.ts
+++ b/src/utils/apiUtils.ts
@@ -16,7 +16,7 @@ const getForcedLoginRedirectForPath = (pathname: string): string | null => {
     if (!path) return null;
 
     // Vendor protected areas
-    if (path.includes("/vendordashboard") || path.includes("/vendordashboard")) {
+    if (path.includes("/vendordashboard")) {
         return "/vendor-login";
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/AnshRaj112/kampyn-frontend/security/code-scanning/33](https://github.com/AnshRaj112/kampyn-frontend/security/code-scanning/33)

To fix this, remove duplicated boolean operands so each `if` condition only contains distinct path checks.  
Best approach (without changing existing behavior): in `src/utils/apiUtils.ts`, edit the vendor protected-area condition to keep only one `path.includes("/vendordashboard")`. This preserves exact functionality while eliminating the CodeQL finding.

No new methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
